### PR TITLE
Remove Google API Key

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -231,7 +231,7 @@ paginate = 10
     custom_css = ["css/custom.css"]
 
     # Google Maps API key (if not set will default to not passing a key.)
-    #googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
+    #googleMapsApiKey = "xxxx"
 
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "blue"


### PR DESCRIPTION
Removes a Google API Key from the config.toml file to prevent false positives in the future.

This key can be found in a lot of repos as it has been copy&pasted a lot afaict, but it would be good to avoid committing secrets in general thus removing it.